### PR TITLE
Fix tmux session handling and stabilize notifications

### DIFF
--- a/wtx
+++ b/wtx
@@ -120,25 +120,36 @@ npm_install_if_needed(){
   fi
 }
 
+tmux_safe_session_name(){
+  local name="$1"
+  # tmux uses ':' to delimit session/window; replace with '_' to create a valid tmux name
+  echo "${name//:/_}"
+}
+
 tmux_start_session(){
   local session="$1" dir="$2"
-  local first_cmd="bash -lc 'source \"$WTX_SCRIPT\"; cd \"$dir\"; wtx env-setup; exec \$SHELL -l'"
-  if tmux has-session -t "$session" 2>/dev/null; then
-    return 0
+  local tmux_name
+  tmux_name="$(tmux_safe_session_name "$session")"
+  local first_cmd="bash -lc 'cd \"$dir\"; \"$WTX_SCRIPT\" env-setup; exec \$SHELL -l -i'"
+  if tmux has-session -t "$tmux_name" 2>/dev/null; then
+    tmux respawn-window -k -t "$tmux_name":0 -c "$dir" "$first_cmd"
+  else
+    tmux new-session -d -s "$tmux_name" -c "$dir" "$first_cmd"
   fi
-  tmux new-session -d -s "$session" -c "$dir" "$first_cmd"
-  tmux set-environment -t "$session" PARENT_BRANCH "$PARENT_BRANCH"
-  tmux set-environment -t "$session" BRANCH "$BRANCH"
+  tmux set-environment -t "$tmux_name" PARENT_BRANCH "$PARENT_BRANCH"
+  tmux set-environment -t "$tmux_name" BRANCH "$BRANCH"
 }
 
 osascript_open_terminal_attach(){
   local session="$1"
   ! is_macos && return 0
   [[ "${WTX_OSA_OPEN}" == "1" ]] || return 0
+  local tmux_name
+  tmux_name="$(tmux_safe_session_name "$session")"
   /usr/bin/osascript <<APPLESCRIPT
 tell application "Terminal"
   activate
-  do script "tmux attach -t ${session}"
+  do script "tmux attach -t ${tmux_name}"
 end tell
 APPLESCRIPT
 }
@@ -254,7 +265,7 @@ cmd_remove(){
   else
     git worktree remove "$WORKTREE"
   fi
-  tmux kill-session -t "$SESSION" 2>/dev/null || true
+  tmux kill-session -t "$(tmux_safe_session_name "$SESSION")" 2>/dev/null || true
   rm -f "$(meta_file_for "$branch")"
   echo "OK"
 }
@@ -272,8 +283,9 @@ cmd_notify(){
   local targets=()
   if [[ "$mode" == "parents" ]]; then
     if [[ -z "${PARENT_BRANCH:-}" ]]; then die "no PARENT_BRANCH known"; fi
-    read_meta "$PARENT_BRANCH" || true  # load parent's session if exists
-    targets+=("$PARENT_BRANCH")
+    local parent_branch="$PARENT_BRANCH"
+    read_meta "$parent_branch" || true  # load parent's session if exists
+    targets+=("$parent_branch")
   elif [[ "$mode" == "children" ]]; then
     targets=()
     while IFS= read -r line; do
@@ -290,12 +302,20 @@ cmd_notify(){
 
   for br in "${targets[@]}"; do
     read_meta "$br" || continue
-    if tmux has-session -t "$SESSION" 2>/dev/null; then
-      tmux display-message -t "$SESSION" -- "$msg"
+    local tmux_name
+    tmux_name="$(tmux_safe_session_name "$SESSION")"
+    if tmux has-session -t "$tmux_name" 2>/dev/null; then
+      tmux display-message -t "$tmux_name" -- "$msg"
       if [[ "$keys" == "1" ]]; then
         # send to first pane of first window
-        local pane; pane="$(tmux list-panes -t "$SESSION" -F '#{pane_id}' | head -n1)"
-        tmux send-keys -t "$pane" "$msg" Enter
+        local pane; pane="$(tmux list-panes -t "$tmux_name" -F '#{pane_id}' | head -n1)"
+        local keys_msg
+        keys_msg="${msg//\\/\\\\}"
+        tmux send-keys -t "$pane" "cd \"$WORKTREE\"" Enter
+        tmux send-keys -t "$pane" "$keys_msg" Enter
+        local run_cmd
+        run_cmd="cd \"$WORKTREE\" && bash -lc $(printf %q "$msg")"
+        tmux run-shell -t "$pane" "$run_cmd"
       fi
       echo "notified $br ($SESSION)"
     fi
@@ -352,7 +372,7 @@ ENV
 NOTES
   - Parent branch is recorded and exported as PARENT_BRANCH.
   - Metadata lives at: $(git_dir 2>/dev/null || echo "<repo>/.git")/wtx.meta/<branch>.env
-  - Each worktree gets a tmux session named "${WTX_SESSION_PREFIX}:<branch>".
+  - Each worktree gets a tmux session named "${WTX_SESSION_PREFIX}:<branch>" (tmux stores it with ':' replaced by '_').
 EOF
 }
 


### PR DESCRIPTION
## Summary
- sanitize and respawn tmux sessions so wtx can reuse worktrees reliably and ensure notify commands execute even when sessions already exist
- harden the flow test by adding tmux-safe helpers and polling for notification artifacts before asserting results

## Testing
- ./test_wtx_flow.sh

------
https://chatgpt.com/codex/tasks/task_e_68de8f06ebcc832f9f94c052b205eab6